### PR TITLE
`ifconfig` path correction for all Linux distributions

### DIFF
--- a/en/functions.sh
+++ b/en/functions.sh
@@ -8,7 +8,7 @@
 # XX can be a two letters code for your plugin, ex: ww for Weather Wunderground
 
 jv_pg_ui_myip () {
-    ifconfig | sed -En 's/127.0.0.1//;s/.*inet (ad[d]?r:)?(([0-9]*\.){3}[0-9]*).*/\2/p'
+    /sbin/ifconfig | sed -En 's/127.0.0.1//;s/.*inet (ad[d]?r:)?(([0-9]*\.){3}[0-9]*).*/\2/p'
 }
 
 jv_pg_ui_start () {

--- a/es/functions.sh
+++ b/es/functions.sh
@@ -8,7 +8,7 @@
 # XX can be a two letters code for your plugin, ex: ww for Weather Wunderground
 
 jv_pg_ui_myip () {
-    ifconfig | sed -En 's/127.0.0.1//;s/.*inet (ad[d]?r:)?(([0-9]*\.){3}[0-9]*).*/\2/p'
+    /sbin/ifconfig | sed -En 's/127.0.0.1//;s/.*inet (ad[d]?r:)?(([0-9]*\.){3}[0-9]*).*/\2/p'
 }
 
 jv_pg_ui_start () {

--- a/fr/functions.sh
+++ b/fr/functions.sh
@@ -8,7 +8,7 @@
 # XX can be a two letters code for your plugin, ex: ww for Weather Wunderground
 
 jv_pg_ui_myip () {
-    ifconfig | sed -En 's/127.0.0.1//;s/.*inet (ad[d]?r:)?(([0-9]*\.){3}[0-9]*).*/\2/p'
+    /sbin/ifconfig | sed -En 's/127.0.0.1//;s/.*inet (ad[d]?r:)?(([0-9]*\.){3}[0-9]*).*/\2/p'
 }
 
 jv_pg_ui_start () {


### PR DESCRIPTION
At list on Debian and Fedora `/sbin/` is not on the path, so calling directly `ifconfig` results in the error `plugins/jarvis-ui/fr/functions.sh: ligne 11: ifconfig : commande introuvable`