### PR TITLE
Change the startup command from python to python2

### DIFF
--- a/functions.sh
+++ b/functions.sh
@@ -2,7 +2,7 @@ jv_pg_ui_start () {
     if jv_plugin_is_enabled "jarvis-api"; then
         jv_debug "Starting User Interface on http://$jv_ip:$jv_pg_ui_port"
         cd "$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-        nohup python -m SimpleHTTPServer $jv_pg_ui_port >/dev/null 2>/dev/stdout & 
+        nohup python2 -m SimpleHTTPServer $jv_pg_ui_port >/dev/null 2>/dev/stdout & 
         cd $jv_dir
     else
         jv_error "ERROR: Jarvis-UI requires Jarvis-API plugin to be installed and enabled"


### PR DESCRIPTION
The `python` command isn't always symlinked on python2 binary on every distribution, for example ArchLinux use Python 3 as a default version for Python so renaming the command from `python` to `python2` is the best way to make this program working on every Linux distribution.

------------------------------
La commande `python` n'est pas toujours liée au binaire `python2` sur chaque distribution, par exemple ArchLinux utilise Python 3 comme version de Python par défaut donc renommer la commande `python` vers `python2` est le meilleur moyen pour que ce programme fonctionne sur toutes les versions distributions Linux.